### PR TITLE
if powerOn is empty, power on by switching to last active input

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -194,11 +194,19 @@ export class LIRCTelevision {
     callback: CharacteristicSetCallback
   ): void {
     if ((this.states.Active && !value) || (!this.states.Active && value)) {
+      let powerOnCommand = this.accessory.context.device.powerOn;
+      if (
+        powerOnCommand === null ||
+        powerOnCommand === undefined ||
+        powerOnCommand.length === 0
+      ) {
+        powerOnCommand = this.accessory.context.device.inputs[
+          this.states.ActiveIdentifier
+        ].command;
+      }
       this.controller
         .sendCommands(
-          value
-            ? this.accessory.context.device.powerOn
-            : this.accessory.context.device.powerOff
+          value ? powerOnCommand : this.accessory.context.device.powerOff
         )
         .then(() => {
           this.tvService.updateCharacteristic(


### PR DESCRIPTION
This will use the button for the last selected input when powering on, if there is no `powerOn` configuration.
It can be useful to reach a known state when powering on, if it has been changed externally.
